### PR TITLE
Add in publishing of Hydrophone time deltas

### DIFF
--- a/models/cobalt/model.sdf
+++ b/models/cobalt/model.sdf
@@ -60,9 +60,24 @@
         <child>right_camera</child>
     </joint>
 
-    <joint name='hydrophone_frame' type="fixed">
-    <parent>frame</parent>
-    <child>hydrophones</child>
+    <joint name='hydrophone_h0_frame' type="fixed">
+        <parent>frame</parent>
+        <child>hydrophone_h0</child>
+    </joint>
+
+    <joint name='hydrophone_hx_frame' type="fixed">
+        <parent>frame</parent>
+        <child>hydrophone_hx</child>
+    </joint>
+
+    <joint name='hydrophone_hy_frame' type="fixed">
+        <parent>frame</parent>
+        <child>hydrophone_hy</child>
+    </joint>
+
+    <joint name='hydrophone_hz_frame' type="fixed">
+        <parent>frame</parent>
+        <child>hydrophone_hz</child>
     </joint>
 
     <link name='hull'>
@@ -173,74 +188,32 @@
       </velocity_decay>
     </link>
 
-    <link name='hydrophones'>
+    <link name='hydrophone_h0'>
       <pose> 0 0 0 0 0 0 </pose>
       <inertial>
         <mass> 0.001 </mass>
       </inertial>
-      <visual name='ref_hydrophone_visual'>
-        <transparency>0.7</transparency>
-        <pose> 0.5 0 0 0 0 0</pose>
-        <geometry>
-          <box>
-              <size> 0.10 0.10 0.10 </size>
-          </box>
-        </geometry>
-        <material>
-            <script>
-              <uri>file://media/materials/scripts/gazebo.material</uri>
-              <name>Gazebo/Black</name>
-            </script>
-          </material>
-      </visual>
+    </link>
 
-      <visual name='x_hydrophone_visual'>
-        <transparency>0.7</transparency>
-        <pose> 0.8 0 0 0 0 0</pose>
-        <geometry>
-            <box>
-                <size> 0.10 0.10 0.10 </size>
-            </box>
-        </geometry>
-            <material>
-                <script>
-                <uri>file://media/materials/scripts/gazebo.material</uri>
-                <name>Gazebo/Black</name>
-                </script>
-            </material>
-        </visual>
+    <link name='hydrophone_hx'>
+      <pose> 3 0 0 0 0 0 </pose>
+      <inertial>
+        <mass> 0.001 </mass>
+      </inertial>
+    </link>
 
-      <visual name='y_hydrophone_visual'>
-        <transparency>0.7</transparency>
-        <pose> 0.5 0.3 0 0 0 0</pose>
-        <geometry>
-          <box>
-              <size> 0.10 0.10 0.10 </size>
-          </box>
-        </geometry>
-        <material>
-            <script>
-              <uri>file://media/materials/scripts/gazebo.material</uri>
-              <name>Gazebo/Black</name>
-            </script>
-          </material>
-      </visual>
+    <link name='hydrophone_hy'>
+      <pose> 0 3 0 0 0 0 </pose>
+      <inertial>
+        <mass> 0.001 </mass>
+      </inertial>
+    </link>
 
-      <visual name='z_hydrophone_visual'>
-        <transparency>0.7</transparency>
-        <pose> 0.5 0 0.3 0 0 0</pose>
-        <geometry>
-          <box>
-              <size> 0.10 0.10 0.10 </size>
-          </box>
-        </geometry>
-        <material>
-            <script>
-              <uri>file://media/materials/scripts/gazebo.material</uri>
-              <name>Gazebo/Black</name>
-            </script>
-          </material>
-      </visual>
+    <link name='hydrophone_hz'>
+      <pose> 0 0 3 0 0 0 </pose>
+      <inertial>
+        <mass> 0.001 </mass>
+      </inertial>
     </link>
 
     <link name='frame'>

--- a/models/cobalt/model.sdf
+++ b/models/cobalt/model.sdf
@@ -60,6 +60,11 @@
         <child>right_camera</child>
     </joint>
 
+    <joint name='hydrophone_frame' type="fixed">
+    <parent>frame</parent>
+    <child>hydrophones</child>
+    </joint>
+
     <link name='hull'>
       <pose>0 0 .082 1.57079632679 0 1.57079632679 </pose>
       <inertial>
@@ -168,6 +173,75 @@
       </velocity_decay>
     </link>
 
+    <link name='hydrophones'>
+      <pose> 0 0 0 0 0 0 </pose>
+      <inertial>
+        <mass> 0.001 </mass>
+      </inertial>
+      <visual name='ref_hydrophone_visual'>
+        <transparency>0.7</transparency>
+        <pose> 0.5 0 0 0 0 0</pose>
+        <geometry>
+          <box>
+              <size> 0.10 0.10 0.10 </size>
+          </box>
+        </geometry>
+        <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+      </visual>
+
+      <visual name='x_hydrophone_visual'>
+        <transparency>0.7</transparency>
+        <pose> 0.8 0 0 0 0 0</pose>
+        <geometry>
+            <box>
+                <size> 0.10 0.10 0.10 </size>
+            </box>
+        </geometry>
+            <material>
+                <script>
+                <uri>file://media/materials/scripts/gazebo.material</uri>
+                <name>Gazebo/Black</name>
+                </script>
+            </material>
+        </visual>
+
+      <visual name='y_hydrophone_visual'>
+        <transparency>0.7</transparency>
+        <pose> 0.5 0.3 0 0 0 0</pose>
+        <geometry>
+          <box>
+              <size> 0.10 0.10 0.10 </size>
+          </box>
+        </geometry>
+        <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+      </visual>
+
+      <visual name='z_hydrophone_visual'>
+        <transparency>0.7</transparency>
+        <pose> 0.5 0 0.3 0 0 0</pose>
+        <geometry>
+          <box>
+              <size> 0.10 0.10 0.10 </size>
+          </box>
+        </geometry>
+        <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Black</name>
+            </script>
+          </material>
+      </visual>
+    </link>
 
     <link name='frame'>
       <pose>0 0 -0.088 0 0 0</pose>

--- a/src/simulator_bridge.cpp
+++ b/src/simulator_bridge.cpp
@@ -6,7 +6,16 @@
 #include "gazebo_msgs/ModelStates.h"
 #include "robosub/ObstaclePosArray.h"
 #include "robosub/QuaternionStampedAccuracy.h"
+#include "robosub/HydrophoneDeltas.h"
 #include "tf/transform_datatypes.h"
+
+#include <cmath>
+#include <vector>
+#include <eigen3/Eigen/Dense>
+#include <eigen3/Eigen/Geometry>
+
+using std::vector;
+using namespace Eigen;
 
 static constexpr double _180_OVER_PI = 180.0 / 3.14159;
 
@@ -15,6 +24,7 @@ ros::Publisher orientation_pub;
 ros::Publisher euler_pub;
 ros::Publisher depth_pub;
 ros::Publisher obstacle_pos_pub;
+ros::Publisher hydrophone_deltas_pub;
 
 // List of names of objects to publish the position and name of. This will be
 // loaded from parameters.
@@ -33,14 +43,15 @@ void modelStatesCallback(const gazebo_msgs::ModelStates& msg)
     robosub::QuaternionStampedAccuracy orientation_msg;
     robosub::depth_stamped depth_msg;
     robosub::Euler euler_msg;
+    vector<Vector3d> hydrophone_positions;
 
     // Find top of water and subs indices in modelstates lists
-    int sub_index = -1;
-    int ceiling_index = -1;
+    int sub_index = -1, pinger_index = -1, ceiling_index = -1;
     for(int i=0; i<msg.name.size(); i++)
     {
-        if(msg.name[i] == "robosub") sub_index = i;
-        if(msg.name[i] == "ceiling_plane") ceiling_index = i;
+        if (msg.name[i] == "robosub") sub_index = i;
+        if (msg.name[i] == "ceiling_plane") ceiling_index = i;
+        if (msg.name[i] == "pinger_a") pinger_index = i;
     }
 
     if(sub_index >= 0)
@@ -80,6 +91,92 @@ void modelStatesCallback(const gazebo_msgs::ModelStates& msg)
                              msg.pose[sub_index].position.z);
             depth_msg.header.stamp = ros::Time::now();
             depth_pub.publish(depth_msg);
+        }
+
+        /*
+         * If the pinger index isn't found, break out and dont perform
+         * hydrophone calculations.
+         */
+        if (pinger_index > -1)
+        {
+            /*
+             * Once the submarine position and orientation are known, calculate
+             * all of the hydrophone positions. Assume the first hydrophone is
+             * 0.5 meters directly in front of the submarine, and that the 3
+             * other reference hydrophones are 0.3 meters along the primary
+             * axes. Begin by setting the hydrophone positions as relative to
+             * the submarine without any rotations applied. They are stored in
+             * order:
+             *      reference, x-axis, y-axis, z-axis
+             */
+            hydrophone_positions.push_back(Vector3d(0.5, 0, 0));
+            hydrophone_positions.push_back(Vector3d(0.8, 0, 0));
+            hydrophone_positions.push_back(Vector3d(0.5, 0.3, 0));
+            hydrophone_positions.push_back(Vector3d(0.5, 0, 0.3));
+
+            /*
+             * Next, create a yaw, pitch, and roll rotation matrix to calculate
+             * the rotated positions relative to the sub. Eigen can represent a
+             * rotation matrix as a quaternion. Then, once they are rotated,
+             * translate them to be with respect to the global frame by adding
+             * in the x, y, and z positions of the submarine.
+             */
+            Eigen::Quaterniond q( orientation_msg.quaternion.w,
+                    orientation_msg.quaternion.x, orientation_msg.quaternion.y,
+                    orientation_msg.quaternion.z);
+
+            for (int i = 0; i < 4; ++i)
+            {
+                hydrophone_positions[i] = q.toRotationMatrix() *
+                        hydrophone_positions[i];
+                hydrophone_positions[i] += Vector3d(position_msg.x,
+                        position_msg.y, position_msg.z);
+            }
+
+            /*
+             * Now that hydrophone positions have been calculated, find the
+             * distance of each hydrophone from the pinger.
+             */
+            vector<double> hydrophone_time_delays;
+            Vector3d pinger_position(msg.pose[pinger_index].position.x,
+                    msg.pose[pinger_index].position.y,
+                    msg.pose[pinger_index].position.z);
+
+            for (int i = 0; i < hydrophone_positions.size(); ++i)
+            {
+                Vector3d delta = hydrophone_positions[i] - pinger_position;
+                double distance = sqrt(delta[0]*delta[0] + delta[1] * delta[1]
+                        + delta[2] * delta[2]);
+
+                /*
+                 * Calculate a ping signal time delay from the distance by
+                 * dividing by the speed of sound in water (1484 m/s).
+                 */
+                double time_delay = distance / 1484.0;
+                hydrophone_time_delays.push_back(time_delay);
+            }
+            /*
+             * Subtract the reference time delay from each hyodrophone time
+             * delay to calculate the time differences in receiving the
+             * hydrophone signal on all of the ordinal hydrophones.
+             */
+            for (unsigned int i = 1; i < hydrophone_time_delays.size(); ++i)
+            {
+                hydrophone_time_delays[i] -= hydrophone_time_delays[0];
+            }
+
+            ROS_INFO_STREAM("Time delays " << hydrophone_time_delays[0] << " "
+                    << hydrophone_time_delays[1]<< " " <<
+                    hydrophone_time_delays[2] << " " <<
+                    hydrophone_time_delays[3]);
+
+            robosub::HydrophoneDeltas deltas;
+            deltas.header.stamp = ros::Time::now();
+            deltas.t1 = ros::Duration(hydrophone_time_delays[1]);
+            deltas.t2 = ros::Duration(hydrophone_time_delays[2]);
+            deltas.t3 = ros::Duration(hydrophone_time_delays[3]);
+
+            hydrophone_deltas_pub.publish(deltas);
         }
     }
 
@@ -126,9 +223,13 @@ int main(int argc, char **argv)
             nh.advertise<robosub::QuaternionStampedAccuracy>("orientation", 1);
     euler_pub = nh.advertise<robosub::Euler>( "orientation/pretty", 1);
     depth_pub = nh.advertise<robosub::depth_stamped>("depth", 1);
-    obstacle_pos_pub = nh.advertise<robosub::ObstaclePosArray>("obstacles/positions", 1);
+    obstacle_pos_pub =
+            nh.advertise<robosub::ObstaclePosArray>("obstacles/positions", 1);
+    hydrophone_deltas_pub = nh.advertise<robosub::HydrophoneDeltas>(
+            "hydrophone/30khz/delta", 1);
 
-    ros::Subscriber orient_sub = nh.subscribe("gazebo/model_states", 1, modelStatesCallback);
+    ros::Subscriber orient_sub = nh.subscribe("gazebo/model_states", 1,
+            modelStatesCallback);
 
     int rate;
     if(!nh.getParam("control/rate", rate))

--- a/src/simulator_bridge.cpp
+++ b/src/simulator_bridge.cpp
@@ -170,9 +170,9 @@ void modelStatesCallback(const gazebo_msgs::ModelStates& msg)
 
             robosub::HydrophoneDeltas deltas;
             deltas.header.stamp = ros::Time::now();
-            deltas.t1 = ros::Duration(hydrophone_time_delays[1]);
-            deltas.t2 = ros::Duration(hydrophone_time_delays[2]);
-            deltas.t3 = ros::Duration(hydrophone_time_delays[3]);
+            deltas.xDelta = ros::Duration(hydrophone_time_delays[1]);
+            deltas.yDelta = ros::Duration(hydrophone_time_delays[2]);
+            deltas.zDelta = ros::Duration(hydrophone_time_delays[3]);
 
             hydrophone_deltas_pub.publish(deltas);
         }

--- a/src/simulator_bridge.cpp
+++ b/src/simulator_bridge.cpp
@@ -121,7 +121,7 @@ void modelStatesCallback(const gazebo_msgs::ModelStates& msg)
              * translate them to be with respect to the global frame by adding
              * in the x, y, and z positions of the submarine.
              */
-            Eigen::Quaterniond q( orientation_msg.quaternion.w,
+            Eigen::Quaterniond q(orientation_msg.quaternion.w,
                     orientation_msg.quaternion.x, orientation_msg.quaternion.y,
                     orientation_msg.quaternion.z);
 
@@ -135,7 +135,9 @@ void modelStatesCallback(const gazebo_msgs::ModelStates& msg)
 
             /*
              * Now that hydrophone positions have been calculated, find the
-             * distance of each hydrophone from the pinger.
+             * distance of each hydrophone from the pinger and translate the
+             * distance into signal time-of-flight as the ping travels through
+             * the water.
              */
             vector<double> hydrophone_time_delays;
             Vector3d pinger_position(msg.pose[pinger_index].position.x,
@@ -155,6 +157,7 @@ void modelStatesCallback(const gazebo_msgs::ModelStates& msg)
                 double time_delay = distance / 1484.0;
                 hydrophone_time_delays.push_back(time_delay);
             }
+
             /*
              * Subtract the reference time delay from each hyodrophone time
              * delay to calculate the time differences in receiving the
@@ -164,11 +167,6 @@ void modelStatesCallback(const gazebo_msgs::ModelStates& msg)
             {
                 hydrophone_time_delays[i] -= hydrophone_time_delays[0];
             }
-
-            ROS_INFO_STREAM("Time delays " << hydrophone_time_delays[0] << " "
-                    << hydrophone_time_delays[1]<< " " <<
-                    hydrophone_time_delays[2] << " " <<
-                    hydrophone_time_delays[3]);
 
             robosub::HydrophoneDeltas deltas;
             deltas.header.stamp = ros::Time::now();

--- a/worlds/underwater.world
+++ b/worlds/underwater.world
@@ -249,6 +249,28 @@
       </link>
     </model>
 
+    <model name="pinger_a">
+      <static>true</static>
+      <pose>35.1 -2.91 -4.9 0 0 0</pose>
+      <link name="link">
+        <visual name="visual">
+          <cast_shadows>true</cast_shadows>
+          <geometry>
+            <cylinder>
+                <radius> 0.03 </radius>
+                <length> 0.15 </length>
+            </cylinder>
+          </geometry>
+          <material>
+            <script>
+              <uri>file://media/materials/scripts/gazebo.material</uri>
+              <name>Gazebo/Grey</name>
+            </script>
+          </material>
+        </visual>
+      </link>
+    </model>
+
     <include>
       <name>gate_side_a</name>
       <pose>12.4 -23.6 -0.9 0 0 -0.9</pose>


### PR DESCRIPTION
Adds in the publishing of time deltas for each of the submarine hydrophones with respect to a pinger. The hydrophones are represented as mostly transparent blocks in front of the submarine. If there is a better method of representing them, their visuals can be changed so as not to interfere with the cameras.
This may not be merged in until https://github.com/PalouseRobosub/robosub/pull/109 is enacted.