### PR TITLE
Adds in Emulated Sensors

### DIFF
--- a/launch/gazebo.launch
+++ b/launch/gazebo.launch
@@ -13,7 +13,9 @@
    <arg name="verbose" value="true"/>
    <arg name="world_name" value="$(find robosub_simulator)/worlds/$(arg world).world"/>
 </include>
-<node name="virtual_serial_port" pkg="robosub_simulator" type="create_thruster_vsp.sh" />
+
+<node name="virtual_serial_port_thruster" pkg="robosub_simulator" type="create_thruster_vsp.sh" />
+<node name="virtual_serial_port_sensor" pkg="robosub_simulator" type="create_sensor_vsp.sh" />
 <node name="simulator_bridge" pkg="robosub_simulator" type="simulator_bridge" required="true" />
 
 <!-- launch basic sub software, unless we are just running the minimal simulator-->

--- a/launch/gazebo.launch
+++ b/launch/gazebo.launch
@@ -22,6 +22,7 @@
 <group unless="$(arg minimal)">
 <node name="control" pkg="robosub" type="control" />
 <node name="thruster" pkg="robosub" type="delayed_node.sh" args="2 thruster_maestro"/>
+<node name="imu" pkg="robosub" type="delayed_node.sh" args="2 bno055_sensor"/>
 </group>
 
 </launch>

--- a/param/simulator.yaml
+++ b/param/simulator.yaml
@@ -14,3 +14,4 @@ simulator:
         lin_accel: 20.0
     ports:
         simulated_thruster: "/dev/null"
+        simulated_sensor: "/dev/null"

--- a/scripts/create_sensor_vsp.sh
+++ b/scripts/create_sensor_vsp.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Utilize socat to create a virtual serial port
+socat pty,raw,echo=0,link=to_sensor_vsp pty,raw,echo=0,link=from_sensor_vsp &
+socat_pid=$!
+
+# Get the absolute paths of the ports.
+port_to_sensors="`pwd`/to_sensor_vsp"
+port_from_sensors="`pwd`/from_sensor_vsp"
+
+# Override parameters to the virtual serial ports.
+rosparam set /ports/sensor $port_to_sensors
+rosparam set /simulator/ports/simulated_sensor $port_from_sensors
+
+# loop forever
+while true
+do
+    sleep 60
+done
+
+trap "kill $socat_pid" EXIT

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,7 +6,11 @@ add_library(buoyancy_improved SHARED buoyancy_improved.cpp)
 add_dependencies(buoyancy_improved  ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 target_link_libraries(buoyancy_improved   ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES})
 
+add_library(sensor SHARED bno055_emulator.cpp serial.cpp)
+add_dependencies(sensor ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(sensor ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES} ${Boost_LIBRARIES})
+
 #simulator bridge
 add_executable(simulator_bridge simulator_bridge.cpp)
 add_dependencies(simulator_bridge ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(simulator_bridge ${catkin_LIBRARIES})
+target_link_libraries(simulator_bridge sensor ${catkin_LIBRARIES})

--- a/src/bno055_emulator.cpp
+++ b/src/bno055_emulator.cpp
@@ -2,37 +2,66 @@
 
 namespace rs
 {
+constexpr uint8_t Bno055Emulator::max_registers[];
+
+/**
+ * Deconstructor.
+ */
+Bno055Emulator::~Bno055Emulator()
+{
+    _port.Close();
+}
 
 /**
  * Initializes the Bno055 Emulator registers to the power-on defaults.
  *
- * @return Zero upon success or a negative error code.
+ * @return None.
  */
-int Bno055Emulator::init()
+void Bno055Emulator::init()
 {
-    int result;
-
-    result |= write_register(Register::PAGE_ID, 0x00);
-    result |= rite_register(Register::CHIP_ID, bno_id);
-    result |= rite_register(Register::ACC_ID, acc_id);
-    result |= rite_register(Register::MAG_ID, mag_id);
-    result |= rite_register(Register::GYR_ID, gyr_id);
-    result |= rite_register(Register::ST_RESULT, 0x0F);
-    result |= rite_register(Register::CALIB_STAT, 0xFF);
-
-    return result;
+    /*
+     * Zero out the memory and set the registers to power-on-reset values.
+     */
+    _current_state = State::None;
+    memset(_registers[0], 0, 0x6A);
+    memset(_registers[1], 0, 0x6A);
+    _registers[0][static_cast<uint8_t>(Register::PAGE_ID)] = 0x00;
+    _registers[0][static_cast<uint8_t>(Register::CHIP_ID)] = bno_id;
+    _registers[0][static_cast<uint8_t>(Register::ACC_ID)] = acc_id;
+    _registers[0][static_cast<uint8_t>(Register::MAG_ID)] = mag_id;
+    _registers[0][static_cast<uint8_t>(Register::GYR_ID)] = gyr_id;
+    _registers[0][static_cast<uint8_t>(Register::ST_RESULT)] = 0x0F;
+    _registers[0][static_cast<uint8_t>(Register::CALIB_STAT)] = 0xFF;
 }
 
+/**
+ * Updates the internal state of the emulator by reading the serial port.
+ *
+ * @return Zero upon success or -1 upon errors.
+ */
 int Bno055Emulator::update()
 {
     while (_port.QueryBuffer() != 0)
     {
         uint8_t byte = 0;
-        if (_port.read(&byte, 1) != 1)
+        if (_port.Read(&byte, 1) != 1)
         {
             ROS_ERROR("Bno Emulator failed to read serial port.");
             return - 1;
         }
+
+        /*ros::Time received_time = ros::Time::now();
+        if (_current_state != State::None && (received_time - _previous_serial_time).toSec() > serial_timeout)
+        {
+            ROS_INFO("Serial timeout occurred.");
+            send_response(Response::Timeout);
+            _current_state = State::None;
+            continue;
+        }
+
+        _previous_serial_time = received_time;
+        */
+        uint8_t page = _registers[0][static_cast<uint8_t>(Register::PAGE_ID)];
 
         switch (_current_state)
         {
@@ -43,14 +72,15 @@ int Bno055Emulator::update()
             case State::None:
                 if (byte == request_header)
                 {
-                    _current_state = RequestHeaderReceived;
+                    _current_state = State::RequestHeaderReceived;
                 }
                 else
                 {
                     /*
                      * If we didn't receive a header, return an error.
                      */
-                    if (send_error(Error::WrongStartByte))
+                    _current_state = State::None;
+                    if (send_response(Response::WrongStartByte))
                     {
                         return -1;
                     }
@@ -67,11 +97,19 @@ int Bno055Emulator::update()
                  * code if byte is neither one or zero. Returning occurs if the
                  * send also fails.
                  */
-                if (byte != 0 && byte != 1 && send_error(Error::MinLength))
+                if (byte != 0 && byte != 1)
                 {
-                    return -1;
+                    _current_state = State::None;
+                    if (send_response(Response::MinLength))
+                    {
+                        return -1;
+                    }
                 }
-                _read_not_write = (byte == 1);
+                else
+                {
+                    _read_not_write = (byte == 1);
+                    _current_state = State::ReadWriteReceived;
+                }
                 break;
 
             /*
@@ -79,69 +117,324 @@ int Bno055Emulator::update()
              * address.
              */
             case State::ReadWriteReceived:
-                if (byte > 0x6A && send_error(Error::InvalidAddress))
+                if (byte > max_registers[page])
                 {
-                    return -1;
-                }
-                _address = byte;
-                break;
-
-            case State::BaseAddressReceived:
-                _length = byte;
-                break;
-
-            case State::LengthReceived:
-                uint8_t page = _registers[0][
-                        static_cast<uint8_t>(Register::PAGE_ID)] & 0x01;
-                if (_address > max_registers[page] &&
-                        send_error(Error::InvalidAddress))
-                {
-                    return -1;
-                }
-
-                if (read_not_write == false)
-                {
-                    registers[page][_address++] = byte;
+                    _current_state = State::None;
+                    if (send_response(Response::InvalidAddress))
+                    {
+                        return -1;
+                    }
                 }
                 else
                 {
-                    if (send_data(_address, _length))
+                    _address = byte;
+                    _current_state = State::BaseAddressReceived;
+                }
+                break;
+
+            /*
+             * Once the base address is received, read the read/write length.
+             */
+            case State::BaseAddressReceived:
+                _length = byte;
+                _current_state = State::LengthReceived;
+                if (_read_not_write)
+                {
+                    if ((_address + _length - 1) > max_registers[page])
+                    {
+                        _current_state = State::None;
+                        if (send_response(Response::InvalidAddress))
+                        {
+                            return -1;
+                        }
+                    }
+                    else
+                    {
+                        /*
+                         * Attempt to send all of the data requested.
+                         */
+                        _current_state = State::None;
+                        if (send_data(_address, _length))
+                        {
+                            return -1;
+                        }
+                    }
+                }
+                break;
+
+            case State::LengthReceived:
+                if (_address > max_registers[page])
+                {
+                    _current_state = State::None;
+                    if (send_response(Response::InvalidAddress))
                     {
                         return -1;
+                    }
+                }
+                else
+                {
+                    /*
+                     * If this is a write command, write the data to the
+                     * register and decrement the length of the request while
+                     * simultaneously increasing the register address.
+                     */
+                    if (_read_not_write == false)
+                    {
+                        /*
+                         * If the user is writing to the reset bit of the
+                         * trigger register, set a system reset.
+                         */
+                        if (_address ==
+                                static_cast<uint8_t>(Register::SYS_TRIGGER) &&
+                                byte & 1 << 5)
+                        {
+                            usleep(300000);
+                            init();
+                            return 0;
+                        }
+                        _registers[page][_address++] = byte;
+                        _length--;
+
+                        if (_length == 0)
+                        {
+                            _current_state = State::None;
+                            if (send_response(Response::WriteSuccess))
+                            {
+                                return -1;
+                            }
+                        }
                     }
                 }
                 break;
         }
     }
 
+    return 0;
 }
 
-void Bno055::setOrientation(double x, double y, double z, double w)
+/**
+ * Sets the quaternion and euler orientation registers.
+ *
+ * @param x X quaternion component.
+ * @param y Y quaternion component.
+ * @param z Z quaternion component.
+ * @param w W quaternion component.
+ *
+ * @return Zero upon success and -1 upon error.
+ */
+int Bno055Emulator::setOrientation(double x, double y, double z, double w)
 {
+    /*
+     * If the sensor is not in a fusion mode, don't set the registers.
+     */
+    if ((_registers[0][static_cast<uint8_t>(Register::OPR_MODE)] & (1 << 3)) ==
+            0)
+    {
+        return 0;
+    }
 
+    /*
+     * If the quaternion is malformed, return an error.
+     */
+    if (x > 1 || y > 1 || z > 1 || w > 1 || x < -1 || y < -1 || z < -1 || w <
+            -1)
+    {
+        return -1;
+    }
+
+    int w_int = static_cast<int16_t>(w * (1 << 14));
+    int x_int = static_cast<int16_t>(x * (1 << 14));
+    int y_int = static_cast<int16_t>(y * (1 << 14));
+    int z_int = static_cast<int16_t>(z * (1 << 14));
+    _registers[0][static_cast<uint8_t>(Register::QUAT_Data_w_MSB)] = w_int >> 8 &
+        0xFF;
+    _registers[0][static_cast<uint8_t>(Register::QUAT_Data_w_LSB)] = w_int &
+        0xFF;
+    _registers[0][static_cast<uint8_t>(Register::QUAT_Data_x_MSB)] = x_int >> 8 &
+        0xFF;
+    _registers[0][static_cast<uint8_t>(Register::QUAT_Data_x_LSB)] = x_int &
+        0xFF;
+    _registers[0][static_cast<uint8_t>(Register::QUAT_Data_y_MSB)] = y_int >> 8 &
+        0xFF;
+    _registers[0][static_cast<uint8_t>(Register::QUAT_Data_y_LSB)] = y_int &
+        0xFF;
+    _registers[0][static_cast<uint8_t>(Register::QUAT_Data_z_MSB)] = z_int >> 8 &
+        0xFF;
+    _registers[0][static_cast<uint8_t>(Register::QUAT_Data_z_LSB)] = z_int &
+        0xFF;
+
+    /*
+     * Convert the quaternion to roll, pitch, and yaw, and then convert the
+     * radians to degrees if necessary. Store the result in the specified
+     * format.
+     */
+    double roll, pitch, yaw;
+    int roll_int, pitch_int, yaw_int;
+    tf::Matrix3x3 m(tf::Quaternion(x, y, z, w));
+    m.getRPY(roll, pitch, yaw);
+
+    /*
+     * Check the unit selection register to see if units are degrees or radians.
+     * A one in bit position 3 of this register indicates radians according to
+     * 4.3.60 of the datasheet.
+     */
+    if (_registers[0][static_cast<uint8_t>(Register::UNIT_SEL)] & 1<<3)
+    {
+        /*
+         * According to table [3-28] of the BNO055 datasheet, each radian is
+         * represented by a value of 900.
+         */
+        roll_int = roll / 900.0;
+        pitch_int = pitch / 900.0;
+        yaw_int = yaw / 900.0;
+    }
+    else
+    {
+        /*
+         * According to table [3-28] of the BNO055 datasheet, each degree is
+         * represented by a value of 16.
+         */
+        roll *= 180.0/3.14159;
+        pitch *= 180.0/3.14159;
+        yaw *= 180.0/3.14159;
+        roll_int = roll / 16.0;
+        pitch_int = pitch / 16.0;
+        yaw_int = yaw / 16.0;
+    }
+    _registers[0][static_cast<uint8_t>(Register::EUL_Pitch_MSB)] = pitch_int >> 8
+        & 0xFF;
+    _registers[0][static_cast<uint8_t>(Register::EUL_Pitch_LSB)] = pitch_int
+        & 0xFF;
+    _registers[0][static_cast<uint8_t>(Register::EUL_Roll_MSB)] = roll_int >> 8
+        & 0xFF;
+    _registers[0][static_cast<uint8_t>(Register::EUL_Roll_LSB)] = roll_int
+        & 0xFF;
+    _registers[0][static_cast<uint8_t>(Register::EUL_Heading_MSB)] = yaw_int >> 8
+        & 0xFF;
+    _registers[0][static_cast<uint8_t>(Register::EUL_Heading_LSB)] = yaw_int
+        & 0xFF;
+
+    return 0;
 }
 
+/**
+ * Sets the linear acceleration registers.
+ *
+ * @param x The linear acceleration along the X axis in m/s^2.
+ * @param y The linear acceleration along the Y axis in m/s^2.
+ * @param z The linear acceleration along the Z axis in m/s^2.
+ *
+ * @return None.
+ */
 void Bno055Emulator::setLinearAcceleration(double x, double y, double z)
 {
+    /*
+     * If the sensor is not in a fusion mode, don't set the registers.
+     */
+    if (!(_registers[0][static_cast<uint8_t>(Register::OPR_MODE)] & (1 << 3)))
+    {
+        return;
+    }
 
+    int x_int, y_int, z_int;
+
+    /*
+     * A value of zero in bit position zero of the unit selection register
+     * indicates units are m/s^2.
+     */
+    if (_registers[0][static_cast<uint8_t>(Register::UNIT_SEL)] & 1 << 0)
+    {
+        /*
+         * Each m/s^2 is represented by 100 LSB according to section 3.6.1 of
+         * the BNO datasheet.
+         */
+        x_int = static_cast<int16_t>(x / 100.0);
+        y_int = static_cast<int16_t>(y / 100.0);
+        z_int = static_cast<int16_t>(z / 100.0);
+    }
+    else
+    {
+        /*
+         * Each mg is represented by 1 LSB according to section 3.6.1 of
+         * the BNO datasheet.
+         */
+        x_int = static_cast<int16_t>(x);
+        y_int = static_cast<int16_t>(y);
+        z_int = static_cast<int16_t>(z);
+    }
+
+    _registers[0][static_cast<uint8_t>(Register::LIA_Data_Z_MSB)] = z_int >> 8 &
+        0xFF;
+    _registers[0][static_cast<uint8_t>(Register::LIA_Data_Z_LSB)] = z_int &
+        0xFF;
+    _registers[0][static_cast<uint8_t>(Register::LIA_Data_Y_MSB)] = y_int >> 8 &
+        0xFF;
+    _registers[0][static_cast<uint8_t>(Register::LIA_Data_Y_LSB)] = y_int &
+        0xFF;
+    _registers[0][static_cast<uint8_t>(Register::LIA_Data_X_MSB)] = x_int >> 8 &
+        0xFF;
+    _registers[0][static_cast<uint8_t>(Register::LIA_Data_X_LSB)] = x_int &
+        0xFF;
 }
 
-int Bno055Emulator::write_registers(Bno055Emulator::Register reg, uint8_t len,
-        const uint8_t *data)
+/**
+ * Writes a response code to the serial port.
+ *
+ * @param response The response code to write.
+ *
+ * @return Zero upon successful write and non-zero upon error.
+ */
+int Bno055Emulator::send_response(Response response)
 {
-
+    uint8_t msg[2] = {error_header, static_cast<uint8_t>(response)};
+    if (response != Response::WriteSuccess)
+    {
+        ROS_INFO_STREAM("Sending response to invalid command: " <<
+                static_cast<int>(response));
+    }
+    return (_port.Write(msg, 2) != 2);
 }
 
-int Bno055Emulator::write_register(Bno055Emulator::Register reg,
-        const uint8_t data)
+/**
+ * Sends data from a base register down the serial port.
+ *
+ * @param addr The register address to start sending data from.
+ * @param len The length in bytes of data to send.
+ *
+ * @return Zero upon success or non-zero upon error.
+ */
+int Bno055Emulator::send_data(uint8_t addr, uint8_t len)
 {
+    int page = _registers[0][static_cast<uint8_t>(Register::PAGE_ID)];
+    if (addr+ len > max_registers[page])
+    {
+        return -1;
+    }
 
+    uint8_t msg[2] = {reply_header, len};
+    if (_port.Write(msg, 2) != 2)
+    {
+        return -1;
+    }
+
+    return (_port.Write(&_registers[page][addr], len) != len);
 }
 
-int Bno055Emulator::read_registers(Bno055Emulator::Register reg, uint8_t len,
-        uint8_t *data)
+/**
+ * Sets up the BNO055 serial port.
+ *
+ * @param port_name The name of the serial port.
+ *
+ * @return Zero upon success or -1 upon error.
+ */
+int Bno055Emulator::setPort(string port_name)
 {
+    if (_port.Open(port_name.c_str(), B115200))
+    {
+        return -1;
+    }
 
+    return 0;
 }
 
 }

--- a/src/bno055_emulator.cpp
+++ b/src/bno055_emulator.cpp
@@ -1,0 +1,147 @@
+#include "bno055_emulator.h"
+
+namespace rs
+{
+
+/**
+ * Initializes the Bno055 Emulator registers to the power-on defaults.
+ *
+ * @return Zero upon success or a negative error code.
+ */
+int Bno055Emulator::init()
+{
+    int result;
+
+    result |= write_register(Register::PAGE_ID, 0x00);
+    result |= rite_register(Register::CHIP_ID, bno_id);
+    result |= rite_register(Register::ACC_ID, acc_id);
+    result |= rite_register(Register::MAG_ID, mag_id);
+    result |= rite_register(Register::GYR_ID, gyr_id);
+    result |= rite_register(Register::ST_RESULT, 0x0F);
+    result |= rite_register(Register::CALIB_STAT, 0xFF);
+
+    return result;
+}
+
+int Bno055Emulator::update()
+{
+    while (_port.QueryBuffer() != 0)
+    {
+        uint8_t byte = 0;
+        if (_port.read(&byte, 1) != 1)
+        {
+            ROS_ERROR("Bno Emulator failed to read serial port.");
+            return - 1;
+        }
+
+        switch (_current_state)
+        {
+            /*
+             * If the current state is none, check to see if we received a
+             * request header.
+             */
+            case State::None:
+                if (byte == request_header)
+                {
+                    _current_state = RequestHeaderReceived;
+                }
+                else
+                {
+                    /*
+                     * If we didn't receive a header, return an error.
+                     */
+                    if (send_error(Error::WrongStartByte))
+                    {
+                        return -1;
+                    }
+                }
+                break;
+
+            /*
+             * Check to see whether we are supposed to conduct a write or a
+             * read.
+             */
+            case State::RequestHeaderReceived:
+                /*
+                 * Note that short-circuiting is used here to send an error
+                 * code if byte is neither one or zero. Returning occurs if the
+                 * send also fails.
+                 */
+                if (byte != 0 && byte != 1 && send_error(Error::MinLength))
+                {
+                    return -1;
+                }
+                _read_not_write = (byte == 1);
+                break;
+
+            /*
+             * Once the read/write command is received, get the register
+             * address.
+             */
+            case State::ReadWriteReceived:
+                if (byte > 0x6A && send_error(Error::InvalidAddress))
+                {
+                    return -1;
+                }
+                _address = byte;
+                break;
+
+            case State::BaseAddressReceived:
+                _length = byte;
+                break;
+
+            case State::LengthReceived:
+                uint8_t page = _registers[0][
+                        static_cast<uint8_t>(Register::PAGE_ID)] & 0x01;
+                if (_address > max_registers[page] &&
+                        send_error(Error::InvalidAddress))
+                {
+                    return -1;
+                }
+
+                if (read_not_write == false)
+                {
+                    registers[page][_address++] = byte;
+                }
+                else
+                {
+                    if (send_data(_address, _length))
+                    {
+                        return -1;
+                    }
+                }
+                break;
+        }
+    }
+
+}
+
+void Bno055::setOrientation(double x, double y, double z, double w)
+{
+
+}
+
+void Bno055Emulator::setLinearAcceleration(double x, double y, double z)
+{
+
+}
+
+int Bno055Emulator::write_registers(Bno055Emulator::Register reg, uint8_t len,
+        const uint8_t *data)
+{
+
+}
+
+int Bno055Emulator::write_register(Bno055Emulator::Register reg,
+        const uint8_t data)
+{
+
+}
+
+int Bno055Emulator::read_registers(Bno055Emulator::Register reg, uint8_t len,
+        uint8_t *data)
+{
+
+}
+
+}

--- a/src/bno055_emulator.h
+++ b/src/bno055_emulator.h
@@ -1,0 +1,203 @@
+#ifndef BNO055_EMULATOR_H
+#define BNO055_EMULATOR_H
+
+#include <map>
+#include <cstdint>
+
+#include "serial.h"
+
+using std::map
+
+namespace rs
+{
+class Bno055Emulator
+{
+    static constexpr uint8_t bno_id = 0xA0;
+    static constexpr uint8_t acc_id = 0xFB;
+    static constexpr uint8_t mag_id = 0x32;
+    static constexpr uint8_t gyr_id = 0x0F;
+    static constexpr uint8_t request_header = 0xAA;
+    static constexpr uint8_t error_header = 0xEE;
+    static constexpr uint8_t reply_header = 0xBB;
+    static constexpr uint8_t max_registers[2] = {0x6B, 0x20};
+
+    enum class State
+    {
+        None,
+        RequestHeaderReceived,
+        ReadWriteReceived,
+        BaseAddressReceived,
+        LengthReceived
+    };
+
+    enum class Response : uint8_t
+    {
+        WriteSuccess = 0x01,
+        ReadFail = 0x02,
+        WriteFail = 0x03,
+        InvalidAddress = 0x04,
+        WriteDisabled = 0x05,
+        WrongStartByte = 0x06,
+        BusOverRun = 0x07,
+        MaxLength = 0x08,
+        MinLength = 0x09,
+        Timeout = 0x0A
+    };
+
+    enum class Register : uint16_t
+    {
+        MAG_RADIUS_MSB = 0x6a,
+        MAG_RADIUS_LSB = 0x69,
+        ACC_RADIUS_MSB = 0x68,
+        ACC_RADIUS_LSB = 0x67,
+        GYR_OFFSET_Z_MSB = 0x66,
+        GYR_OFFSET_Z_LSB = 0x65,
+        GYR_OFFSET_Y_MSB = 0x64,
+        GYR_OFFSET_Y_LSB = 0x63,
+        GYR_OFFSET_X_MSB = 0x62,
+        GYR_OFFSET_X_LSB = 0x61,
+        MAG_OFFSET_Z_MSB = 0x60,
+        MAG_OFFSET_Z_LSB = 0x5f,
+        MAG_OFFSET_Y_MSB = 0x5e,
+        MAG_OFFSET_Y_LSB = 0x5d,
+        MAG_OFFSET_X_MSB = 0x5c,
+        MAG_OFFSET_X_LSB = 0x5b,
+        ACC_OFFSET_Z_MSB = 0x5a,
+        ACC_OFFSET_Z_LSB = 0x59,
+        ACC_OFFSET_Y_MSB = 0x58,
+        ACC_OFFSET_Y_LSB = 0x57,
+        ACC_OFFSET_X_MSB = 0x56,
+        ACC_OFFSET_X_LSB = 0x55,
+        AXIS_MAP_SIGN = 0x42,
+        AXIS_MAP_CONFIG = 0x41,
+        TEMP_SOURCE = 0x40,
+        SYS_TRIGGER = 0x3F,
+        PWR_MODE = 0x3E,
+        OPR_MODE = 0x3D,
+        UNIT_SEL = 0x3B,
+        SYS_ERROR = 0x3A,
+        SYS_STATUS = 0x39,
+        SYS_CLK_STATUS = 0x38,
+        INT_STA = 0x37,
+        ST_RESULT = 0x36,
+        CALIB_STAT = 0x35,
+        TEMP = 0x34,
+        GRV_Data_Z_MSB = 0x33,
+        GRV_Data_Z_LSB = 0x32,
+        GRV_Data_Y_MSB = 0x31,
+        GRV_Data_Y_LSB = 0x30,
+        GRV_Data_X_MSB = 0x2f,
+        GRV_Data_X_LSB = 0x2e,
+        LIA_Data_Z_MSB = 0x2d,
+        LIA_Data_Z_LSB = 0x2c,
+        LIA_Data_Y_MSB = 0x2b,
+        LIA_Data_Y_LSB = 0x2a,
+        LIA_Data_X_MSB = 0x29,
+        LIA_Data_X_LSB = 0x28,
+        QUAT_Data_z_MSB = 0x27,
+        QUAT_Data_z_LSB = 0x26,
+        QUAT_Data_y_MSB = 0x25,
+        QUAT_Data_y_LSB = 0x24,
+        QUAT_Data_x_MSB = 0x23,
+        QUAT_Data_x_LSB = 0x22,
+        QUAT_Data_w_MSB = 0x21,
+        QUAT_Data_w_LSB = 0x20,
+        EUL_Pitch_MSB = 0x1F,
+        EUL_Pitch_LSB = 0x1E,
+        EUL_Roll_MSB = 0x1D,
+        EUL_Roll_LSB = 0x1C,
+        EUL_Heading_MSB = 0x1B,
+        EUL_Heading_LSB = 0x1A,
+        GYR_DATA_Z_MSB = 0x19,
+        GYR_DATA_Z_LSB = 0x18,
+        GYR_DATA_Y_MSB = 0x17,
+        GYR_DATA_Y_LSB = 0x16,
+        GYR_DATA_X_MSB = 0x15,
+        GYR_DATA_X_LSB = 0x14,
+        MAG_DATA_Z_MSB = 0x13,
+        MAG_DATA_Z_LSB = 0x12,
+        MAG_DATA_Y_MSB = 0x11,
+        MAG_DATA_Y_LSB = 0x10,
+        MAG_DATA_X_MSB = 0x0f,
+        MAG_DATA_X_LSB = 0x0e,
+        ACC_DATA_Z_MSB = 0x0d,
+        ACC_DATA_Z_LSB = 0x0c,
+        ACC_DATA_Y_MSB = 0x0b,
+        ACC_DATA_Y_LSB = 0x0a,
+        ACC_DATA_X_MSB = 0x09,
+        ACC_DATA_X_LSB = 0x08,
+        PAGE_ID = 0x07,
+        BL_Rev_ID = 0x06,
+        SW_REV_ID_MSB = 0x05,
+        SW_REV_ID_LSB = 0x04,
+        GYR_ID = 0x03,
+        MAG_ID = 0x02,
+        ACC_ID = 0x01,
+        CHIP_ID = 0x00,
+
+        /*
+         * Special note: UNIQUE_ID is 16 bytes long. This is the starting
+         * location of this register.
+         */
+        UNIQUE_ID = 0x150,
+        GYR_AM_SET = 0x11f,
+        GYR_AM_THRES = 0x11e,
+        GYR_DUR_Z = 0x11d,
+        GYR_HR_Z_SET = 0x11c,
+        GYR_DUR_Y = 0x11b,
+        GYR_HR_Y_SET = 0x11a,
+        GYR_DUR_X = 0x11d,
+        GYR_HR_X_SET = 0x118,
+        GYR_INT_SETTING = 0x117,
+        ACC_NM_SET = 0x116,
+        ACC_NM_THRES = 0x115,
+        ACC_HG_THRES = 0x114,
+        ACC_HG_DURATION = 0x113,
+        ACC_INT_Settings = 0x112,
+        ACC_AM_THRES = 0x111,
+        INT_EN = 0x110,
+        INT_MASK = 0x10f,
+        GYR_Sleep_Config = 0x10d,
+        ACC_Sleep_Config = 0x10c,
+        GYR_Config_1 = 0x10b,
+        GYR_Config_0 = 0x10a,
+        MAG_Config = 0x109,
+        ACC_Config = 0x108
+    };
+
+public:
+    Bno055Emulator(Serial &port) :
+        _port(port),
+        _registers(),
+        _read_not_write(true),
+        _length(0),
+        _address(0)
+    {
+        /*
+         * Ensure register space is initialized to zero.
+         */
+        memset(registers[0], 0, 0x6A);
+        memset(registers[1], 0, 0x6A);
+    }
+
+    int init();
+    int update();
+    void setOrientation(double x, double y, double z, double w);
+    void setLinearAcceleration(double x, double y, double z);
+
+private:
+    int write_registers(Register reg, uint8_t len, const uint8_t *data);
+    int write_register(Register reg, const uint8_t data);
+    int read_registers(Register reg, uint8_t len, uint8_t *data);
+    int send_error(Error error);
+
+    Serial &_port;
+    uint8_t _registers[2][0x6A];
+    State _current_state;
+    bool _read_not_write;
+    uint8_t _length;
+    uint8_t _address;
+};
+}
+
+#endif //BNO055_EMULATOR_H

--- a/src/maestro_emulator.cpp
+++ b/src/maestro_emulator.cpp
@@ -37,7 +37,7 @@ int MaestroEmulator::init(string port_name,
     /*
      * Open and configure the virtual serial port.
      */
-    if (_port.Open(port_name.c_str(), B9600))
+    if (_port.Open(port_name.c_str(), 115200))
     {
         ROS_FATAL("Failed to open serial port.");
         return -1;

--- a/src/serial.cpp
+++ b/src/serial.cpp
@@ -135,13 +135,13 @@ namespace rs
              * Wait for atleast one byte to be available before reading so that
              * timeout is also valid if no bytes are received on the port.
              */
-            ros::Time exit_time = ros::Time::now() + ros::Duration(0.5);
-            while (QueryBuffer() == 0 && ros::Time::now() < exit_time)
+            ros::WallTime exit_time = ros::WallTime::now() + ros::WallDuration(0.5);
+            while (QueryBuffer() == 0 && ros::WallTime::now() < exit_time)
             {
-                ros::Duration(0.02).sleep();
+                ros::WallDuration(0.02).sleep();
             }
 
-            if (ros::Time::now() > exit_time)
+            if (ros::WallTime::now() > exit_time)
             {
                 ROS_INFO("No serial bytes were available");
                 return 0;
@@ -191,11 +191,12 @@ namespace rs
         struct termios options = {0};
         int fd = this->m_port_fd;
 
-        ROS_INFO("configuring serial port");
+        ROS_INFO_STREAM("configuring serial port:" << m_port_name);
 
         if (tcgetattr(this->m_port_fd, &options) != 0)
         {
-            ROS_ERROR("Failed to get serial attributes.");
+            ROS_ERROR_STREAM("Failed to get serial attributes for " <<
+                    m_port_name);
         }
 
         options.c_iflag = 0; //no input handling
@@ -227,7 +228,8 @@ namespace rs
 
         if (tcsetattr(fd, TCSANOW, &options) != 0)
         {
-            ROS_ERROR("Failed to set the serial port options.");
+            ROS_ERROR_STREAM("Failed to set the serial port options for " <<
+                    m_port_name);
         }
     }
 };


### PR DESCRIPTION
By adding in emulation for sensors similar to the new thrusters, we can accurately test the robosub IMU node to verify that this is functioning. Note that during testing, I actually discovered a bug with bno055_sensor.cpp. As a result, this pull request can not be merged in until both https://github.com/PalouseRobosub/robosub/pull/202 and https://github.com/PalouseRobosub/robosub/pull/203, and rsummers/sensor-fix are merged into the robosub repository.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub_simulator/71)
<!-- Reviewable:end -->
