### PR TITLE
Rate Namespace Fixes

### DIFF
--- a/launch/gazebo.launch
+++ b/launch/gazebo.launch
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <launch>
 <rosparam command="load" file="$(find robosub)/param/cobalt.yaml"/>
 <rosparam command="load" file="$(find robosub_simulator)/param/cobalt_sim.yaml"/>
@@ -23,6 +24,7 @@
 <node name="control" pkg="robosub" type="control" />
 <node name="thruster" pkg="robosub" type="delayed_node.sh" args="2 thruster_maestro"/>
 <node name="imu" pkg="robosub" type="delayed_node.sh" args="2 bno055_sensor"/>
+<node name="hydrophones" pkg="robosub" type="delayed_node.sh" args="2 hydrophones"/>
 </group>
 
 </launch>

--- a/param/cobalt_sim.yaml
+++ b/param/cobalt_sim.yaml
@@ -1,7 +1,11 @@
 # this settings file should be loaded after cobalt.yaml is loaded, is designed
 # for overwritting settings that should be different in the simulator
+rate:
+    control: 50
+    depth: 20
+    sensor: 20
+
 control:
-    rate: 50
     proportional:
         x: 1.0
         y: 1.0
@@ -42,3 +46,5 @@ control:
         translation: 0.5
     buoyancy_offset: -2.5
 
+thrusters:
+    timeout: 0.5

--- a/param/cobalt_sim.yaml
+++ b/param/cobalt_sim.yaml
@@ -3,7 +3,7 @@
 rate:
     control: 50
     depth: 20
-    sensor: 20
+    imu: 20
 
 control:
     proportional:

--- a/param/simulator.yaml
+++ b/param/simulator.yaml
@@ -1,14 +1,16 @@
 # This file is for general simulator params
+rate:
+    # The rate at which the simulator bridge runs, this must be faster
+    #  than any rates used for topics published by the simulator
+    #  such as control, depth, sensor, etc. (see cobalt_sim.yaml)
+    simulator_bridge: 30
+
 simulator:
-    thruster_timeout: 0.5
     visualize_thrusters: true
     visualizer_update_rate: 10
     bridge_rates:
-        max: 30.0
         position: 10.0
-        orientation: 20.0
         euler: 20.0
-        depth: 20.0
         obstacle_pos: 1.0
         hydrophone_deltas: 10.0
         lin_accel: 20.0

--- a/param/simulator.yaml
+++ b/param/simulator.yaml
@@ -1,19 +1,20 @@
 # This file is for general simulator params
 rate:
-    # The rate at which the simulator bridge runs, this must be faster
-    #  than any rates used for topics published by the simulator
-    #  such as control, depth, sensor, etc. (see cobalt_sim.yaml)
-    simulator_bridge: 30
+    simulator:
+        # The rate at which the simulator bridge runs, this must be faster
+        #  than any rates used for topics published by the simulator
+        #  such as control, depth, sensor in cobalt_sim.yaml and
+        #  any rate parameters below
+        simulator_bridge: 30
+        position: 10
+        euler: 20
+        obstacle_pos: 1
+        hydrophone_deltas: 10
+        lin_accel: 20
 
 simulator:
     visualize_thrusters: true
     visualizer_update_rate: 10
-    bridge_rates:
-        position: 10.0
-        euler: 20.0
-        obstacle_pos: 1.0
-        hydrophone_deltas: 10.0
-        lin_accel: 20.0
     ports:
         simulated_thruster: "/dev/null"
         simulated_sensor: "/dev/null"

--- a/src/simulator_bridge.cpp
+++ b/src/simulator_bridge.cpp
@@ -309,20 +309,19 @@ int main(int argc, char **argv)
     ros::NodeHandle nh;
 
     position_pub = ThrottledPublisher<geometry_msgs::Vector3>
-        ("real/position", 1, 0, "simulator/bridge_rates/position");
+        ("real/position", 1, 0, "rate/simulator/position");
     orientation_pub = ThrottledPublisher<robosub::QuaternionStampedAccuracy>
         ("real/orientation", 1, 0, "rate/sensor");
     euler_pub = ThrottledPublisher<robosub::Euler>
-        ("real/pretty/orientation", 1, 0, "simulator/bridge_rates/euler");
+        ("real/pretty/orientation", 1, 0, "rate/simulator/euler");
     depth_pub = ThrottledPublisher<robosub::Float32Stamped>
         ("depth", 1, 0, "rate/depth");
     obstacle_pos_pub = ThrottledPublisher<robosub::ObstaclePosArray>
-        ("obstacles/positions", 1, 0, "simulator/bridge_rates/obstacle_pos");
+        ("obstacles/positions", 1, 0, "rate/simulator/obstacle_pos");
     hydrophone_deltas_pub = ThrottledPublisher<robosub::HydrophoneDeltas>
-        ("hydrophones/30khz/delta", 1, 0,
-         "simulator/bridge_rates/hydrophone_deltas");
+        ("hydrophones/30khz/delta", 1, 0, "rate/simulator/hydrophone_deltas");
     lin_accel_pub = ThrottledPublisher<geometry_msgs::Vector3Stamped>
-        ("real/acceleration/linear", 1, 0, "simulator/bridge_rates/lin_accel");
+        ("real/acceleration/linear", 1, 0, "rate/simulator/lin_accel");
 
     ros::Subscriber orient_sub = nh.subscribe("gazebo/model_states", 1,
             modelStatesCallback);
@@ -334,7 +333,7 @@ int main(int argc, char **argv)
             imuCallback);
 
     double rate;
-    if(!nh.getParam("rate/simulator_bridge", rate))
+    if(!nh.getParam("rate/simulator/simulator_bridge", rate))
     {
         ROS_ERROR_STREAM("failed to load max simulator bridge rate");
         return 0;

--- a/src/simulator_bridge.cpp
+++ b/src/simulator_bridge.cpp
@@ -311,11 +311,11 @@ int main(int argc, char **argv)
     position_pub = ThrottledPublisher<geometry_msgs::Vector3>
         ("real/position", 1, 0, "simulator/bridge_rates/position");
     orientation_pub = ThrottledPublisher<robosub::QuaternionStampedAccuracy>
-        ("real/orientation", 1, 0, "simulator/bridge_rates/orientation");
+        ("real/orientation", 1, 0, "rate/sensor");
     euler_pub = ThrottledPublisher<robosub::Euler>
         ("real/pretty/orientation", 1, 0, "simulator/bridge_rates/euler");
     depth_pub = ThrottledPublisher<robosub::Float32Stamped>
-        ("depth", 1, 0, "simulator/bridge_rates/depth");
+        ("depth", 1, 0, "rate/depth");
     obstacle_pos_pub = ThrottledPublisher<robosub::ObstaclePosArray>
         ("obstacles/positions", 1, 0, "simulator/bridge_rates/obstacle_pos");
     hydrophone_deltas_pub = ThrottledPublisher<robosub::HydrophoneDeltas>
@@ -334,7 +334,7 @@ int main(int argc, char **argv)
             imuCallback);
 
     double rate;
-    if(!nh.getParam("simulator/bridge_rates/max", rate))
+    if(!nh.getParam("rate/simulator_bridge", rate))
     {
         ROS_ERROR_STREAM("failed to load max simulator bridge rate");
         return 0;

--- a/src/simulator_bridge.cpp
+++ b/src/simulator_bridge.cpp
@@ -311,7 +311,7 @@ int main(int argc, char **argv)
     position_pub = ThrottledPublisher<geometry_msgs::Vector3>
         ("real/position", 1, 0, "rate/simulator/position");
     orientation_pub = ThrottledPublisher<robosub::QuaternionStampedAccuracy>
-        ("real/orientation", 1, 0, "rate/sensor");
+        ("real/orientation", 1, 0, "rate/imu");
     euler_pub = ThrottledPublisher<robosub::Euler>
         ("real/pretty/orientation", 1, 0, "rate/simulator/euler");
     depth_pub = ThrottledPublisher<robosub::Float32Stamped>


### PR DESCRIPTION
Fixes #69 and adds the hydrophone node into the nodes launched by gazebo.launch by default.

@ryan-summers the `rate/sensor` parameter is pretty generic, can we update it to be something along the lines of `rate/bno_055`?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub_simulator/84)
<!-- Reviewable:end -->
