### PR TITLE
Camera Update

### DIFF
--- a/models/cobalt/model.sdf
+++ b/models/cobalt/model.sdf
@@ -528,8 +528,8 @@
           <camera>
               <horizontal_fov>3.1415</horizontal_fov>
               <image>
-                  <width>640</width>
-                  <height>640</height>
+                  <width>1384</width>
+                  <height>1032</height>
               </image>
               <clip>
                   <near>0.001</near>
@@ -538,9 +538,9 @@
               <lens>
                   <type>custom</type>
                   <custom_function>
-                      <c1>691.5</c1>   
-                      <c2>515.5</c2>     
-                      <f>341.43251966606937</f>    
+                      <c1>685.4</c1>
+                      <c2>525.2</c2>
+                      <f>307.53251966606937</f>
                       <fun>tan</fun>
                   </custom_function>
                   <scale_to_hfov>true</scale_to_hfov>
@@ -597,8 +597,8 @@
           <camera>
               <horizontal_fov>3.1415</horizontal_fov>
               <image>
-                  <width>640</width>
-                  <height>640</height>
+                  <width>1384</width>
+                  <height>1032</height>
               </image>
               <clip>
                   <near>0.1</near>
@@ -607,9 +607,9 @@
               <lens>
                   <type>custom</type>
                   <custom_function>
-                      <c1>691.5</c1>   
-                      <c2>515.5</c2>     
-                      <f>341.43251966606937</f>    
+                      <c1>667.1</c1>
+                      <c2>536.7</c2>
+                      <f>317.86251966606937</f>
                       <fun>tan</fun>
                   </custom_function>
                   <scale_to_hfov>true</scale_to_hfov>
@@ -666,8 +666,8 @@
           <camera>
               <horizontal_fov>3.1415</horizontal_fov>
               <image>
-                  <width>640</width>
-                  <height>640</height>
+                  <width>1384</width>
+                  <height>1032</height>
               </image>
               <clip>
                   <near>0.1</near>

--- a/models/cobalt/model.sdf
+++ b/models/cobalt/model.sdf
@@ -558,7 +558,7 @@
           </camera>
           <plugin name="left_camera_controller" filename="libgazebo_ros_camera.so">
               <cameraName>left</cameraName>
-              <imageTopicName>/camera/left</imageTopicName>
+              <imageTopicName>/camera/left/image_raw</imageTopicName>
           </plugin>
           <always_on>1</always_on>
           <update_rate>5</update_rate>
@@ -627,7 +627,7 @@
           </camera>
           <plugin name="right_camera_controller" filename="libgazebo_ros_camera.so">
               <cameraName>right</cameraName>
-              <imageTopicName>/camera/right</imageTopicName>
+              <imageTopicName>/camera/right/image_raw</imageTopicName>
           </plugin>
           <always_on>1</always_on>
           <update_rate>5</update_rate>
@@ -696,7 +696,7 @@
           </camera>
           <plugin name="bottom_camera_controller" filename="libgazebo_ros_camera.so">
               <cameraName>bottom</cameraName>
-              <imageTopicName>/camera/bottom</imageTopicName>
+              <imageTopicName>/camera/bottom/image_raw</imageTopicName>
           </plugin>
           <always_on>1</always_on>
           <update_rate>5</update_rate>


### PR DESCRIPTION
Modifies cameras to publish full size images which are needed to perform proper undistortion as well as publishing to `image_raw`.

Requires PalouseRobosub/robosub#246.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub_simulator/93)
<!-- Reviewable:end -->
