### PR TITLE
Publish sub model's position as point instead of vector

### DIFF
--- a/src/simulator_bridge.cpp
+++ b/src/simulator_bridge.cpp
@@ -37,8 +37,6 @@ ThrottledPublisher<robosub::ObstaclePosArray> obstacle_pos_pub;
 ThrottledPublisher<robosub::HydrophoneDeltas> hydrophone_deltas_pub;
 ThrottledPublisher<geometry_msgs::Vector3Stamped> lin_accel_pub;
 
-
-
 // List of names of objects to publish the position and name of. This will be
 // loaded from parameters.
 std::vector<std::string> object_names;

--- a/src/simulator_bridge.cpp
+++ b/src/simulator_bridge.cpp
@@ -3,6 +3,7 @@
 #include "robosub/Euler.h"
 #include "geometry_msgs/Vector3Stamped.h"
 #include "geometry_msgs/PointStamped.h"
+#include "geometry_msgs/Pose.h"
 #include "gazebo_msgs/ModelState.h"
 #include "gazebo_msgs/ModelStates.h"
 #include "gazebo_msgs/LinkStates.h"
@@ -246,7 +247,10 @@ void modelStatesCallback(const gazebo_msgs::ModelStates& msg)
 
     // Publish sub position and orientation
 
-    publishTfFrame(msg.pose[sub_index], "cobalt_sim");
+    geometry_msgs::Pose subTFPose;
+    subTFPose.orientation = orientation_msg.quaternion;
+    subTFPose.position = position_msg.point;
+    publishTfFrame(subTFPose, "cobalt_sim");
     position_pub.publish(position_msg);
     orientation_pub.publish(orientation_msg);
     depth_pub.publish(depth_msg);

--- a/src/simulator_bridge.cpp
+++ b/src/simulator_bridge.cpp
@@ -336,7 +336,7 @@ int main(int argc, char **argv)
     ros::NodeHandle nh;
 
     position_pub = ThrottledPublisher<geometry_msgs::PointStamped>
-        ("real/position", 1, 0, "rate/simulator/position");
+        ("simulator/cobalt/position", 1, 0, "rate/simulator/position");
     orientation_pub = ThrottledPublisher<geometry_msgs::QuaternionStamped>
         ("real/orientation", 1, 0, "rate/imu");
     euler_pub = ThrottledPublisher<robosub::Euler>

--- a/src/simulator_bridge.cpp
+++ b/src/simulator_bridge.cpp
@@ -28,7 +28,7 @@ static constexpr double _180_OVER_PI = 180.0 / 3.14159;
 
 Bno055Emulator bno_emulator;
 
-ThrottledPublisher<geometry_msgs::Vector3> position_pub;
+ThrottledPublisher<geometry_msgs::PointStamped> position_pub;
 ThrottledPublisher<geometry_msgs::QuaternionStamped> orientation_pub;
 ThrottledPublisher<robosub::Euler> euler_pub;
 ThrottledPublisher<robosub::Float32Stamped> depth_pub;
@@ -124,7 +124,7 @@ void linkStatesCallback(const gazebo_msgs::LinkStates &msg)
 // well as a list (defined in params) of objects
 void modelStatesCallback(const gazebo_msgs::ModelStates& msg)
 {
-    geometry_msgs::Vector3 position_msg;
+    geometry_msgs::PointStamped position_msg;
     geometry_msgs::QuaternionStamped orientation_msg;
     robosub::Float32Stamped depth_msg;
     robosub::Euler euler_msg;
@@ -182,12 +182,16 @@ void modelStatesCallback(const gazebo_msgs::ModelStates& msg)
                      msg.pose[sub_index].position.z);
     depth_msg.header.stamp = ros::Time::now();
 
+    // Construct header for the sub's position
+    position_msg.header.stamp = ros::Time::now();
+    position_msg.header.frame_id = "world";
+
     // Copy sub pos to position msg
-    position_msg.x = msg.pose[sub_index].position.x;
-    position_msg.y = msg.pose[sub_index].position.y;
-    position_msg.z = depth_msg.data;
-    position_msg.x -= pinger_position[0];
-    position_msg.y -= pinger_position[1];
+    position_msg.point.x = msg.pose[sub_index].position.x;
+    position_msg.point.y = msg.pose[sub_index].position.y;
+    position_msg.point.z = depth_msg.data;
+    position_msg.point.x -= pinger_position[0];
+    position_msg.point.y -= pinger_position[1];
 
     orientation_msg.quaternion.x = msg.pose[sub_index].orientation.x;
     orientation_msg.quaternion.y = msg.pose[sub_index].orientation.y;
@@ -308,7 +312,7 @@ int main(int argc, char **argv)
 
     ros::NodeHandle nh;
 
-    position_pub = ThrottledPublisher<geometry_msgs::Vector3>
+    position_pub = ThrottledPublisher<geometry_msgs::PointStamped>
         ("real/position", 1, 0, "rate/simulator/position");
     orientation_pub = ThrottledPublisher<geometry_msgs::QuaternionStamped>
         ("real/orientation", 1, 0, "rate/imu");

--- a/src/simulator_bridge.cpp
+++ b/src/simulator_bridge.cpp
@@ -2,6 +2,7 @@
 #include "robosub/Float32Stamped.h"
 #include "robosub/Euler.h"
 #include "geometry_msgs/Vector3Stamped.h"
+#include "geometry_msgs/PointStamped.h"
 #include "gazebo_msgs/ModelState.h"
 #include "gazebo_msgs/ModelStates.h"
 #include "gazebo_msgs/LinkStates.h"


### PR DESCRIPTION
Previously, the sub's model position (as provided by Gazebo) was published as a point instead of a vector. This data type can't be rendered in RViz, making testing/etc. difficult.

Publishing as a point gives us the ability to view the sub's simulated position in RViz, as well as provide a base for publishing the position onto the tf-tree.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub_simulator/103)
<!-- Reviewable:end -->
