### PR TITLE
Add error-calculator for localization estimate vs. Gazebo sub location

### DIFF
--- a/launch/gazebo.launch
+++ b/launch/gazebo.launch
@@ -18,6 +18,7 @@
 <node name="virtual_serial_port_sensor" pkg="robosub_simulator" type="create_sensor_vsp.sh" />
 <node name="virtual_serial_port_thruster" pkg="robosub_simulator" type="create_thruster_vsp.sh" />
 <node name="simulator_bridge" pkg="robosub_simulator" type="simulator_bridge" required="true" />
+<node name="localization_harness" pkg="robosub_simulator" type="localization_harness" required="true" />
 
 <!-- launch basic sub software, unless we are just running the minimal simulator-->
 <group unless="$(arg minimal)">

--- a/launch/gazebo.launch
+++ b/launch/gazebo.launch
@@ -18,10 +18,10 @@
 <node name="virtual_serial_port_sensor" pkg="robosub_simulator" type="create_sensor_vsp.sh" />
 <node name="virtual_serial_port_thruster" pkg="robosub_simulator" type="create_thruster_vsp.sh" />
 <node name="simulator_bridge" pkg="robosub_simulator" type="simulator_bridge" required="true" />
-<node name="localization_harness" pkg="robosub_simulator" type="localization_harness" required="true" />
 
 <!-- launch basic sub software, unless we are just running the minimal simulator-->
 <group unless="$(arg minimal)">
+  <node name="localization_harness" pkg="robosub_simulator" type="localization_harness" output="screen" />
   <node name="control" pkg="robosub" type="control" />
   <node name="imu" pkg="robosub" type="imu">
     <param name="active_imu" value="bno055_left"/>

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,3 +20,8 @@ add_executable(simulator_bridge simulator_bridge.cpp)
 add_dependencies(simulator_bridge ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
 
 target_link_libraries(simulator_bridge sensor ${catkin_LIBRARIES})
+
+# Localization engine diag harness/error calculator
+add_executable(localization_harness localization_harness.cpp)
+add_dependencies(localization_harness ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
+target_link_libraries(localization_harness ${catkin_LIBRARIES})

--- a/src/localization_harness.cpp
+++ b/src/localization_harness.cpp
@@ -7,7 +7,6 @@
 
 int main(int argc, char **argv)
 {
-
     ros::init(argc, argv, "localization_harness");
 
     ros::NodeHandle nh;
@@ -28,8 +27,8 @@ int main(int argc, char **argv)
     tflr.waitForTransform("cobalt", "cobalt_sim", ros::Time::now(),
         ros::Duration(0.01));
 
-    while (ros::ok()) {
-
+    while (ros::ok())
+    {
         tflr.lookupTransform("cobalt", "cobalt_sim", ros::Time(0),
             resultantTransform);
 
@@ -41,7 +40,5 @@ int main(int argc, char **argv)
         loc_error_msg.header.stamp = ros::Time::now();
 
         loc_error_pub.publish<robosub::Float32Stamped>(loc_error_msg);
-
     }
-
 }

--- a/src/localization_harness.cpp
+++ b/src/localization_harness.cpp
@@ -1,0 +1,47 @@
+#include "ros/ros.h"
+#include "robosub/Float32Stamped.h"
+#include "tf/transform_listener.h"
+#include "tf/transform_datatypes.h"
+
+#include <string>
+
+int main(int argc, char **argv)
+{
+
+    ros::init(argc, argv, "localization_harness");
+
+    ros::NodeHandle nh;
+
+    tf::TransformListener tflr;
+
+    tf::StampedTransform resultantTransform;
+
+    ros::Publisher loc_error_pub = nh.advertise<robosub::Float32Stamped>(
+        "localization/error/linear", 1);
+
+    // Wait for a transform to be available between the localization engine's
+    // position and the simulator's position.
+
+    ROS_DEBUG(
+        "Waiting for available transformation from cobalt to cobalt_sim...");
+
+    tflr.waitForTransform("cobalt", "cobalt_sim", ros::Time::now(),
+        ros::Duration(0.01));
+
+    while (ros::ok()) {
+
+        tflr.lookupTransform("cobalt", "cobalt_sim", ros::Time(0),
+            resultantTransform);
+
+        double loc_error = resultantTransform.getOrigin().length();
+
+        robosub::Float32Stamped loc_error_msg;
+
+        loc_error_msg.data = loc_error;
+        loc_error_msg.header.stamp = ros::Time::now();
+
+        loc_error_pub.publish<robosub::Float32Stamped>(loc_error_msg);
+
+    }
+
+}

--- a/src/localization_harness.cpp
+++ b/src/localization_harness.cpp
@@ -14,7 +14,7 @@ int main(int argc, char **argv)
 
     ros::NodeHandle nh;
 
-    ros::Rate publishRate(100.0);
+    ros::Rate publishRate(30.0);
 
     tf2_ros::Buffer tfb;
     tf2_ros::TransformListener tflr(tfb);

--- a/src/localization_harness.cpp
+++ b/src/localization_harness.cpp
@@ -72,4 +72,6 @@ int main(int argc, char **argv)
             ROS_WARN("Caught LookupException: %s", ex.what());
         }
     }
+
+    return 0;
 }

--- a/src/localization_harness.cpp
+++ b/src/localization_harness.cpp
@@ -24,21 +24,31 @@ int main(int argc, char **argv)
     ROS_DEBUG(
         "Waiting for available transformation from cobalt to cobalt_sim...");
 
-    tflr.waitForTransform("cobalt", "cobalt_sim", ros::Time::now(),
-        ros::Duration(0.01));
+    tflr.waitForTransform(tflr.resolve("cobalt_sim"), tflr.resolve("cobalt"), ros::Time::now(),
+        ros::Duration(60.0));
 
     while (ros::ok())
     {
-        tflr.lookupTransform("cobalt", "cobalt_sim", ros::Time(0),
+        try {
+            tflr.lookupTransform(tflr.resolve("cobalt_sim"), tflr.resolve("cobalt"), ros::Time(0),
             resultantTransform);
 
-        double loc_error = resultantTransform.getOrigin().length();
+            double loc_error = resultantTransform.getOrigin().length();
 
-        robosub::Float32Stamped loc_error_msg;
+            robosub::Float32Stamped loc_error_msg;
 
-        loc_error_msg.data = loc_error;
-        loc_error_msg.header.stamp = ros::Time::now();
+            loc_error_msg.data = loc_error;
+            loc_error_msg.header.stamp = ros::Time::now();
 
-        loc_error_pub.publish<robosub::Float32Stamped>(loc_error_msg);
+            loc_error_pub.publish<robosub::Float32Stamped>(loc_error_msg);
+
+        }
+        catch (tf::LookupException ex) {
+
+            ROS_WARN("Caught LookupException: %s", ex.what());
+
+        }
+
+
     }
 }

--- a/src/localization_harness.cpp
+++ b/src/localization_harness.cpp
@@ -35,7 +35,7 @@ int main(int argc, char **argv)
     ROS_DEBUG(
         "Waiting for available transformation from cobalt to cobalt_sim...");
 
-    while (nh.ok())
+    while (ros::ok())
     {
         try
         {

--- a/src/localization_harness.cpp
+++ b/src/localization_harness.cpp
@@ -21,7 +21,7 @@ int main(int argc, char **argv)
 
     ros::Publisher vector_error_pub =
         nh.advertise<geometry_msgs::Vector3Stamped>("localization/error/vector",
-        1);
+                                                    1);
 
 
     // Wait for a transform to be available between the localization engine's
@@ -34,13 +34,14 @@ int main(int argc, char **argv)
 
     while (!isTransformAvailable)
     {
-        isTransformAvailable = tflr.waitForTransform(tflr.resolve("cobalt_sim"),
-            tflr.resolve("cobalt"), ros::Time::now(), ros::Duration(300.0));
+        isTransformAvailable = tflr.waitForTransform("cobalt_sim", "cobalt",
+                                                     ros::Time::now(),
+                                                     ros::Duration(300.0));
 
         if (!isTransformAvailable)
         {
             ROS_WARN("No TF frames from cobalt to cobalt_sim have appeared in "
-                "the last 5 minutes.");
+                     "the last 5 minutes.");
         }
     }
 
@@ -49,8 +50,8 @@ int main(int argc, char **argv)
     {
         try
         {
-            tflr.lookupTransform(tflr.resolve("cobalt_sim"),
-                tflr.resolve("cobalt"), ros::Time(0), resultantTransform);
+            tflr.lookupTransform("cobalt_sim", "cobalt", ros::Time(0),
+                                 resultantTransform);
 
             tf::Vector3 error_vector = resultantTransform.getOrigin();
 

--- a/src/localization_harness.cpp
+++ b/src/localization_harness.cpp
@@ -12,6 +12,8 @@ int main(int argc, char **argv)
 
     ros::NodeHandle nh;
 
+    ros::Rate publishRate(200.0);
+
     tf::TransformListener tflr;
 
     tf::StampedTransform resultantTransform;
@@ -71,6 +73,8 @@ int main(int argc, char **argv)
         {
             ROS_WARN("Caught LookupException: %s", ex.what());
         }
+
+        publishRate.sleep();
     }
 
     return 0;

--- a/src/localization_harness.cpp
+++ b/src/localization_harness.cpp
@@ -30,8 +30,21 @@ int main(int argc, char **argv)
     ROS_DEBUG(
         "Waiting for available transformation from cobalt to cobalt_sim...");
 
-    tflr.waitForTransform(tflr.resolve("cobalt_sim"), tflr.resolve("cobalt"),
-        ros::Time::now(), ros::Duration(60.0));
+    bool isTransformAvailable = false;
+
+    while (!isTransformAvailable)
+    {
+        isTransformAvailable = tflr.waitForTransform(tflr.resolve("cobalt_sim"),
+            tflr.resolve("cobalt"), ros::Time::now(), ros::Duration(300.0));
+
+        if (!isTransformAvailable)
+        {
+            ROS_WARN("No TF frames from cobalt to cobalt_sim have appeared in "
+                "the last 5 minutes.");
+        }
+
+    }
+
 
     while (ros::ok())
     {

--- a/src/localization_harness.cpp
+++ b/src/localization_harness.cpp
@@ -12,7 +12,7 @@ int main(int argc, char **argv)
 
     ros::NodeHandle nh;
 
-    ros::Rate publishRate(200.0);
+    ros::Rate publishRate(100.0);
 
     tf::TransformListener tflr;
 

--- a/src/localization_harness.cpp
+++ b/src/localization_harness.cpp
@@ -42,7 +42,6 @@ int main(int argc, char **argv)
             ROS_WARN("No TF frames from cobalt to cobalt_sim have appeared in "
                 "the last 5 minutes.");
         }
-
     }
 
 


### PR DESCRIPTION
This PR adds a node (`localization_harness`) that utilizes the newly-published `cobalt_sim` TF frame generated from Gazebo data (as implemented in #103) and the `cobalt` TF frame generated using localization-system output (as implemented in PalouseRobosub/robosub#327) and and outputs two topics: 
* `/localization/error/vector` the error as a `geometry_msgs::Vector3Stamped`
* `/localization/error/linear`, the above vector's length (so localization-accuracy tests only need to verify "Do the floats published by this topic never exceed _x_?")

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub_simulator/105)
<!-- Reviewable:end -->
