### PR TITLE
Properly tuned the new PID parameters

### DIFF
--- a/param/cobalt_sim.yaml
+++ b/param/cobalt_sim.yaml
@@ -17,8 +17,8 @@ control:
         x: 0.0
         y: 0.0
         z: 0.0
-        psi: 0.35
-        phi: 0.35
+        psi: 0.37
+        phi: 0.33
         theta: 0.0
     derivative:
         x: 0.0

--- a/param/cobalt_sim.yaml
+++ b/param/cobalt_sim.yaml
@@ -9,31 +9,31 @@ control:
     proportional:
         x: 1.0
         y: 1.0
-        z: 2.0
-        psi: 2.0  #roll
-        phi: 2.0  #pitch
-        theta: 0.07 #yaw
+        z: 3.0
+        psi: 0.24  #roll
+        phi: 0.24  #pitch
+        theta: 0.08 #yaw
     integral:
         x: 0.0
         y: 0.0
-        z: 0.1
-        psi: 1.0
-        phi: 1.0
-        theta: 0.1
+        z: 0.0
+        psi: 0.35
+        phi: 0.35
+        theta: 0.0
     derivative:
         x: 0.0
         y: 0.0
         z: 1.0
-        psi: 2.0
-        phi: 2.0
-        theta: 0.25
+        psi: 0.5
+        phi: 0.5
+        theta: 0.14
     windup:
-        x: 5.0
-        y: 5.0
+        x: 0.0
+        y: 0.0
         z: 0.1
-        psi: 10.0
-        phi: 10.0
-        theta: 0.1
+        psi: 50.0
+        phi: 50.0
+        theta: 0.0
     hysteresis:
         x: 0.0
         y: 0.0

--- a/param/simulator.yaml
+++ b/param/simulator.yaml
@@ -5,7 +5,7 @@ rate:
         #  than any rates used for topics published by the simulator
         #  such as control, depth, sensor in cobalt_sim.yaml and
         #  any rate parameters below
-        simulator_bridge: 150
+        simulator_bridge: 30
         position: 10
         euler: 20
         obstacle_pos: 1

--- a/param/simulator.yaml
+++ b/param/simulator.yaml
@@ -5,7 +5,7 @@ rate:
         #  than any rates used for topics published by the simulator
         #  such as control, depth, sensor in cobalt_sim.yaml and
         #  any rate parameters below
-        simulator_bridge: 30
+        simulator_bridge: 150
         position: 10
         euler: 20
         obstacle_pos: 1


### PR DESCRIPTION
Parameters were tuned using the Ziegler-Nichols method. I'm really not sure how the old parameters happened to pass the tests with improper derivative calculations, but whatevs! This should fix the heartache of the other AI devs :P The simulator_bridge frequency was increased to ensure that the IMU node publishes faster than 5 Hz (this causes a large lag in the derivative calculation and causes the control system to perform sub-optimally).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub_simulator/112)
<!-- Reviewable:end -->
