### PR TITLE
Corrected vision distance and added stereo_node.py to launch file

### DIFF
--- a/launch/gazebo.launch
+++ b/launch/gazebo.launch
@@ -34,11 +34,18 @@
     <node name="sim_network_left" type="sim_vision_network.py" pkg="robosub_simulator">
         <param name="fisheye_camera_file" value="$(find robosub_simulator)/param/left_calibration.json" />
         <param name="camera" value="left"/>
+        <param name="max_distance" value="7"/>
     </node>
     <node name="sim_network_right" type="sim_vision_network.py" pkg="robosub_simulator">
         <param name="fisheye_camera_file" value="$(find robosub_simulator)/param/right_calibration.json" />
         <param name="camera" value="right"/>
+        <param name="max_distance" value="7"/>
     </node>
 </group>
+
+<node name="stereo_vision" type="stereo_node.py" pkg="robosub">
+    <param name="camera_separation" value="0.40"/>
+    <param name="focal_distance" value="442"/>
+</node>
 
 </launch>


### PR DESCRIPTION
The vision nodes had just slightly too short of a range. The max distance should be able to see the start gate posts from being placed in the water, but were unable to. Additionally, the stereo vision node should be started on launch.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub_simulator/115)
<!-- Reviewable:end -->
