### PR TITLE
Added in timestampping for simulated vision network nodes

### DIFF
--- a/scripts/sim_vision_network.py
+++ b/scripts/sim_vision_network.py
@@ -454,6 +454,7 @@ def camera_callback(image):
     # Clear the boxes list to indicate the message has been sent.
     boxes = []
 
+    detections_msg.header.stamp = rospy.Time.now()
     detection_pub.publish(detections_msg)
 
     # Display the un-fisheye'd image with bounding points, link origins, and


### PR DESCRIPTION
This fix corrects https://github.com/PalouseRobosub/robosub_simulator/issues/122

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/palouserobosub/robosub_simulator/125)
<!-- Reviewable:end -->
